### PR TITLE
Extend pluginOptions to also cover gulp-sourcemaps

### DIFF
--- a/lib/init-option-defaults.js
+++ b/lib/init-option-defaults.js
@@ -1,5 +1,6 @@
 var BundleKeys = require('./model/bundle-keys'),
-  gutil = require('gulp-util');
+  gutil = require('gulp-util'),
+  defaults = require('lodash').defaults;
 
 module.exports = function (bundle) {
   bundle[BundleKeys.OPTIONS] = bundle[BundleKeys.OPTIONS] || {};
@@ -11,5 +12,6 @@ module.exports = function (bundle) {
   bundle[BundleKeys.OPTIONS].pluginOptions['gulp-minify-css'] = bundle[BundleKeys.OPTIONS].pluginOptions['gulp-minify-css'] || {};
   bundle[BundleKeys.OPTIONS].pluginOptions['gulp-uglify'] = bundle[BundleKeys.OPTIONS].pluginOptions['gulp-uglify'] || {};
   bundle[BundleKeys.OPTIONS].pluginOptions['gulp-concat'] = bundle[BundleKeys.OPTIONS].pluginOptions['gulp-concat'] || {};
+  bundle[BundleKeys.OPTIONS].pluginOptions['gulp-sourcemaps'] = defaults(bundle[BundleKeys.OPTIONS].pluginOptions['gulp-sourcemaps'] || {}, {loadMaps: true});
   bundle[BundleKeys.OPTIONS].order = bundle[BundleKeys.OPTIONS].order || {};
 };

--- a/lib/init-option-defaults.js
+++ b/lib/init-option-defaults.js
@@ -2,6 +2,12 @@ var BundleKeys = require('./model/bundle-keys'),
   gutil = require('gulp-util'),
   defaults = require('lodash').defaults;
 
+var sourcemapDefaults = {
+  init: {loadMaps: true},
+  write: {},
+  destPath: 'maps'
+};
+
 module.exports = function (bundle) {
   bundle[BundleKeys.OPTIONS] = bundle[BundleKeys.OPTIONS] || {};
   bundle[BundleKeys.OPTIONS].transforms = bundle[BundleKeys.OPTIONS].transforms || {};
@@ -12,6 +18,17 @@ module.exports = function (bundle) {
   bundle[BundleKeys.OPTIONS].pluginOptions['gulp-minify-css'] = bundle[BundleKeys.OPTIONS].pluginOptions['gulp-minify-css'] || {};
   bundle[BundleKeys.OPTIONS].pluginOptions['gulp-uglify'] = bundle[BundleKeys.OPTIONS].pluginOptions['gulp-uglify'] || {};
   bundle[BundleKeys.OPTIONS].pluginOptions['gulp-concat'] = bundle[BundleKeys.OPTIONS].pluginOptions['gulp-concat'] || {};
-  bundle[BundleKeys.OPTIONS].pluginOptions['gulp-sourcemaps'] = defaults(bundle[BundleKeys.OPTIONS].pluginOptions['gulp-sourcemaps'] || {}, {loadMaps: true});
+
+  bundle[BundleKeys.OPTIONS].pluginOptions['gulp-sourcemaps'] = defaults(bundle[BundleKeys.OPTIONS].pluginOptions['gulp-sourcemaps'] || {}, sourcemapDefaults);
+
+  // This is to get a clone of the base options
+  var sourcemapBaseOpts = defaults({}, bundle[BundleKeys.OPTIONS].pluginOptions['gulp-sourcemaps']);
+  // Remove the style and script sub attributes
+  delete sourcemapDefaults[BundleKeys.SCRIPTS];
+  delete sourcemapDefaults[BundleKeys.STYLES];
+
+  bundle[BundleKeys.OPTIONS].pluginOptions['gulp-sourcemaps'][BundleKeys.SCRIPTS] = defaults(bundle[BundleKeys.OPTIONS].pluginOptions['gulp-sourcemaps'][BundleKeys.SCRIPTS] || {}, sourcemapBaseOpts);
+  bundle[BundleKeys.OPTIONS].pluginOptions['gulp-sourcemaps'][BundleKeys.STYLES] = defaults(bundle[BundleKeys.OPTIONS].pluginOptions['gulp-sourcemaps'][BundleKeys.STYLES] || {}, sourcemapBaseOpts);
+
   bundle[BundleKeys.OPTIONS].order = bundle[BundleKeys.OPTIONS].order || {};
 };

--- a/lib/stream-files.js
+++ b/lib/stream-files.js
@@ -54,7 +54,7 @@ module.exports.scripts = function (opts) {
     }))
     .pipe(gif(function (file) {
         return sourcemaps.isEnabled(opts);
-      }, gsourcemaps.init({loadMaps: true})
+      }, gsourcemaps.init(opts.bundleOptions.pluginOptions['gulp-sourcemaps'])
     ))
     .pipe(opts.bundleOptions.transforms[BundleKeys.SCRIPTS]())
     .on('error', function (e) {
@@ -94,7 +94,7 @@ module.exports.scripts = function (opts) {
     ))
     .pipe(gif(function (file) {
         return sourcemaps.isEnabled(opts);
-      }, gsourcemaps.write('maps')
+      }, gsourcemaps.write('maps', opts.bundleOptions.pluginOptions['gulp-sourcemaps'])
     ))
     .pipe(addBundleResultsToFile(opts.bundleName, BundleKeys.SCRIPTS, opts.bundleOptions.result, opts.env, opts.isBundleAll));
 };
@@ -111,7 +111,7 @@ module.exports.styles = function (opts) {
     .pipe(
     gif(function (file) {
         return sourcemaps.isEnabled(opts);
-      }, gsourcemaps.init({loadMaps: true})
+      }, gsourcemaps.init(opts.bundleOptions.pluginOptions['gulp-sourcemaps'])
     ))
     .pipe(opts.bundleOptions.transforms[BundleKeys.STYLES]())
     .on('error', function (e) {
@@ -132,7 +132,7 @@ module.exports.styles = function (opts) {
     .pipe(gif(isOptionEnabled(opts.bundleOptions.rev, opts.env), rev()))
     .pipe(gif(function (file) {
         return sourcemaps.isEnabled(opts);
-      }, gsourcemaps.write('maps')
+      }, gsourcemaps.write('maps', opts.bundleOptions.pluginOptions['gulp-sourcemaps'])
     ))
     .pipe(addBundleResultsToFile(opts.bundleName, BundleKeys.STYLES, opts.bundleOptions.result, opts.env, opts.isBundleAll));
 };

--- a/lib/stream-files.js
+++ b/lib/stream-files.js
@@ -54,7 +54,7 @@ module.exports.scripts = function (opts) {
     }))
     .pipe(gif(function (file) {
         return sourcemaps.isEnabled(opts);
-      }, gsourcemaps.init(opts.bundleOptions.pluginOptions['gulp-sourcemaps'])
+      }, gsourcemaps.init(opts.bundleOptions.pluginOptions['gulp-sourcemaps'][BundleKeys.SCRIPTS].init)
     ))
     .pipe(opts.bundleOptions.transforms[BundleKeys.SCRIPTS]())
     .on('error', function (e) {
@@ -94,7 +94,10 @@ module.exports.scripts = function (opts) {
     ))
     .pipe(gif(function (file) {
         return sourcemaps.isEnabled(opts);
-      }, gsourcemaps.write('maps', opts.bundleOptions.pluginOptions['gulp-sourcemaps'])
+      }, gsourcemaps.write(
+        opts.bundleOptions.pluginOptions['gulp-sourcemaps'][BundleKeys.SCRIPTS].destPath,
+        opts.bundleOptions.pluginOptions['gulp-sourcemaps'][BundleKeys.SCRIPTS].write
+      )
     ))
     .pipe(addBundleResultsToFile(opts.bundleName, BundleKeys.SCRIPTS, opts.bundleOptions.result, opts.env, opts.isBundleAll));
 };
@@ -111,7 +114,7 @@ module.exports.styles = function (opts) {
     .pipe(
     gif(function (file) {
         return sourcemaps.isEnabled(opts);
-      }, gsourcemaps.init(opts.bundleOptions.pluginOptions['gulp-sourcemaps'])
+      }, gsourcemaps.init(opts.bundleOptions.pluginOptions['gulp-sourcemaps'][BundleKeys.STYLES].init)
     ))
     .pipe(opts.bundleOptions.transforms[BundleKeys.STYLES]())
     .on('error', function (e) {
@@ -132,7 +135,10 @@ module.exports.styles = function (opts) {
     .pipe(gif(isOptionEnabled(opts.bundleOptions.rev, opts.env), rev()))
     .pipe(gif(function (file) {
         return sourcemaps.isEnabled(opts);
-      }, gsourcemaps.write('maps', opts.bundleOptions.pluginOptions['gulp-sourcemaps'])
+      }, gsourcemaps.write(
+        opts.bundleOptions.pluginOptions['gulp-sourcemaps'][BundleKeys.STYLES].destPath,
+        opts.bundleOptions.pluginOptions['gulp-sourcemaps'][BundleKeys.STYLES].write
+      )
     ))
     .pipe(addBundleResultsToFile(opts.bundleName, BundleKeys.STYLES, opts.bundleOptions.result, opts.env, opts.isBundleAll));
 };

--- a/test/unit/stream-files-test.js
+++ b/test/unit/stream-files-test.js
@@ -38,7 +38,8 @@ describe('stream-files', function () {
             pluginOptions: {
               'gulp-minify-css': {},
               'gulp-uglify': {},
-              'gulp-concat': {}
+              'gulp-concat': {},
+              'gulp-sourcemaps': {'scripts': {}, 'styles': {}}
             },
             order: {}
           }
@@ -74,7 +75,8 @@ describe('stream-files', function () {
             pluginOptions: {
               'gulp-minify-css': {},
               'gulp-uglify': {},
-              'gulp-concat': {}
+              'gulp-concat': {},
+              'gulp-sourcemaps': {'scripts': {}, 'styles': {}}
             },
             order: {}
           }


### PR DESCRIPTION
As per issue #64 

Currently this both the options for sourcemap.init and sourcemap.write compressed into the same option.

I can't see any option conflicts upstream, so I don't think this would be an issue.